### PR TITLE
Add GitHub AkiLogin, make app session-aware and update Firebase defaults

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { OfflineBanner } from './components/OfflineBanner';
 import React, { Suspense, lazy, useEffect, useState } from 'react';
 import { lazyPage } from './router/lazy';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { onAuthStateChanged, type User } from 'firebase/auth';
 
 // Import Layout synchronously to prevent loading block
 import Layout from './components/Layout';
@@ -18,6 +19,7 @@ import RequireAdmin from './components/auth/RequireAdmin';
 import { logDebug } from './utils/logger';
 import { registerServiceWorker, captureInstallPrompt } from './services/pwaService';
 import { PWAInstallBanner } from './components/ui/PWAInstallBanner';
+import { auth } from './lib/firebase';
 
 const _langProviderImport = import('./context/LanguageProvider');
 
@@ -120,6 +122,7 @@ const GamificationProfilePage = lazy(() => import('./pages/GamificationProfilePa
 const LeaderboardPage = lazy(() => import('./pages/LeaderboardPage'));
 const BadgesPage = lazy(() => import('./pages/BadgesPage'));
 const Login = lazy(() => import('./pages/Login'));
+const AkiLogin = lazy(() => import('./views/auth/AkiLogin'));
 const Inscription = lazy(() => import('./pages/Inscription'));
 const ResetPassword = lazy(() => import('./pages/ResetPassword'));
 const MonCompte = lazy(() => import('./pages/MonCompte'));
@@ -392,6 +395,23 @@ function LoadingFallback() {
 
 export default function App() {
   const [providerError, setProviderError] = useState<Error | null>(null);
+  const [sessionUser, setSessionUser] = useState<User | null>(null);
+  const [sessionReady, setSessionReady] = useState(false);
+
+  useEffect(() => {
+    if (!auth) {
+      setSessionReady(true);
+      return;
+    }
+
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      setSessionUser(user);
+      setSessionReady(true);
+    });
+
+    return unsubscribe;
+  }, []);
+
   useEffect(() => {
     const fallback = document.getElementById('loading-fallback');
     if (fallback) fallback.style.display = 'none';
@@ -413,6 +433,10 @@ export default function App() {
         </button>
       </div>
     );
+  }
+
+  if (!sessionReady) {
+    return <LoadingFallback />;
   }
 
   return (
@@ -576,8 +600,20 @@ export default function App() {
                                     element={<LeaderboardPage />}
                                   />
                                   <Route path="gamification/badges" element={<BadgesPage />} />
-                                  <Route path="login" element={<Login />} />
-                                  <Route path="connexion" element={<Login />} />
+                                  <Route
+                                    path="login"
+                                    element={sessionUser ? <Navigate to="/" replace /> : <Login />}
+                                  />
+                                  <Route
+                                    path="connexion"
+                                    element={sessionUser ? <Navigate to="/" replace /> : <Login />}
+                                  />
+                                  <Route
+                                    path="aki-login"
+                                    element={
+                                      sessionUser ? <Navigate to="/" replace /> : <AkiLogin />
+                                    }
+                                  />
                                   <Route path="inscription" element={<Inscription />} />
                                   <Route path="reset-password" element={<ResetPassword />} />
                                   <Route path="auth" element={<AuthHub />} />

--- a/frontend/src/lib/firebase.ts
+++ b/frontend/src/lib/firebase.ts
@@ -14,14 +14,16 @@ import { getInstallations } from 'firebase/installations';
 // working without a .env file.  In production the secrets MUST be set so
 // the correct apiKey is embedded; the fallback is only a last resort.
 const firebaseConfig = {
-  apiKey: import.meta.env.VITE_FIREBASE_API_KEY || 'AIzaSyDf_m8BzMVHFWoFhVLyThuKwWTMhB7u5ZY',
-  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN || 'a-ki-pri-sa-ye.firebaseapp.com',
-  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID || 'a-ki-pri-sa-ye',
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY || 'AIzaSyDby4HIcb0K_-pZssF6OmKoSjNi7TcvqlQ',
+  authDomain:
+    import.meta.env.VITE_FIREBASE_AUTH_DOMAIN || 'akiprisaye-officielle.firebaseapp.com',
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID || 'akiprisaye-officielle',
   storageBucket:
-    import.meta.env.VITE_FIREBASE_STORAGE_BUCKET || 'a-ki-pri-sa-ye.firebasestorage.app',
-  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID || '187272078809',
-  appId: import.meta.env.VITE_FIREBASE_APP_ID || '1:187272078809:web:501d916973a75edb06e5c8',
-  measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID || 'G-W0R1B4HHE1',
+    import.meta.env.VITE_FIREBASE_STORAGE_BUCKET || 'akiprisaye-officielle.appspot.com',
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID || '147409182593',
+  appId:
+    import.meta.env.VITE_FIREBASE_APP_ID || '1:147409182593:web:75e81d77320548922b91c8',
+  measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID,
 };
 
 // Detect missing VITE_FIREBASE_* secrets so diagnostic pages (Login, StatutPage)

--- a/frontend/src/views/auth/AkiLogin.tsx
+++ b/frontend/src/views/auth/AkiLogin.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { GithubAuthProvider, signInWithPopup, signInWithRedirect } from 'firebase/auth';
+
+import { auth } from '@/lib/firebase';
+
+function isMobileDevice(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  return /Android|iPhone|iPad|iPod|IEMobile|Opera Mini/i.test(navigator.userAgent);
+}
+
+export default function AkiLogin() {
+  const navigate = useNavigate();
+  const [busy, setBusy] = useState(false);
+
+  const provider = useMemo(() => {
+    const githubProvider = new GithubAuthProvider();
+    githubProvider.addScope('read:user');
+    githubProvider.addScope('user:email');
+    githubProvider.setCustomParameters({ allow_signup: 'true' });
+    return githubProvider;
+  }, []);
+
+  useEffect(() => {
+    if (!auth) return;
+    const unsubscribe = auth.onAuthStateChanged((user) => {
+      if (user) {
+        navigate('/', { replace: true });
+      }
+    });
+    return unsubscribe;
+  }, [navigate]);
+
+  const handleGithubSignIn = async () => {
+    if (!auth) {
+      console.error('[AkiLogin] Firebase auth indisponible');
+      return;
+    }
+
+    setBusy(true);
+    try {
+      if (isMobileDevice()) {
+        await signInWithRedirect(auth, provider);
+        return;
+      }
+      await signInWithPopup(auth, provider);
+      navigate('/', { replace: true });
+    } catch (error) {
+      console.error('[AkiLogin] Erreur Firebase GitHub OAuth:', error);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[#06090f] flex items-center justify-center p-6 text-white text-center">
+      <div className="w-full max-w-md bg-[#0d1117] p-10 rounded-[3rem] border border-blue-500/20 shadow-2xl">
+        <h2 className="text-2xl font-black mb-4 text-blue-500 italic">AKI HORIZON v17</h2>
+        <p className="text-[9px] text-gray-500 mb-8 uppercase tracking-widest">
+          ID: Iv23licpHW2aEri3J4Q
+        </p>
+        <button
+          type="button"
+          onClick={handleGithubSignIn}
+          disabled={busy}
+          className="w-full py-5 bg-[#24292f] text-white rounded-2xl font-black flex items-center justify-center gap-4 border border-white/10 active:scale-95 transition-all disabled:opacity-70"
+        >
+          <img
+            src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+            className="w-6 h-6 invert"
+            alt="GitHub"
+          />
+          {busy ? 'CONNEXION…' : 'ENTRER VIA GITHUB'}
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation

- Add a GitHub-based login entrypoint and prevent showing login pages to already-authenticated users.
- Ensure the app waits for Firebase auth state to avoid flashes and incorrect route rendering on first load.
- Update Firebase fallback configuration values to the new official project defaults.

### Description

- Introduces a new `AkiLogin` view at `frontend/src/views/auth/AkiLogin.tsx` that implements GitHub OAuth using `signInWithPopup` / `signInWithRedirect` with mobile detection.
- Makes `App.tsx` session-aware by importing `onAuthStateChanged` and `User`, adding `sessionUser` and `sessionReady` state, waiting for auth state before rendering (`LoadingFallback`), and redirecting authenticated users away from `login`/`connexion` routes while adding an `aki-login` route.
- Updates default Firebase configuration values in `frontend/src/lib/firebase.ts` (API key, auth domain, project ID, storage bucket, messaging sender ID, and app ID) to point to the new project defaults used when build-time env vars are not provided.

### Testing

- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f00347aa7c832b850b0035e9e752b5)