### PR TITLE
Add GitHub OAuth flow and AkiLogin view; wire provider, routes and firebase defaults

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -120,6 +120,7 @@ const GamificationProfilePage = lazy(() => import('./pages/GamificationProfilePa
 const LeaderboardPage = lazy(() => import('./pages/LeaderboardPage'));
 const BadgesPage = lazy(() => import('./pages/BadgesPage'));
 const Login = lazy(() => import('./pages/Login'));
+const AkiLogin = lazy(() => import('./views/auth/AkiLogin'));
 const Inscription = lazy(() => import('./pages/Inscription'));
 const ResetPassword = lazy(() => import('./pages/ResetPassword'));
 const MonCompte = lazy(() => import('./pages/MonCompte'));
@@ -391,29 +392,12 @@ function LoadingFallback() {
 }
 
 export default function App() {
-  const [providerError, setProviderError] = useState<Error | null>(null);
   useEffect(() => {
     const fallback = document.getElementById('loading-fallback');
     if (fallback) fallback.style.display = 'none';
     captureInstallPrompt();
     registerServiceWorker();
   }, []);
-
-  if (providerError) {
-    return (
-      <div className="min-h-screen flex flex-col items-center justify-center bg-slate-900 text-white p-4">
-        <h1 className="text-xl font-bold mb-2">Erreur d'initialisation</h1>
-        <p className="text-red-400 mb-4">{providerError.message}</p>
-        <button
-          type="button"
-          onClick={() => window.location.reload()}
-          className="px-6 py-3 bg-blue-600 rounded-lg hover:bg-blue-700"
-        >
-          Recharger
-        </button>
-      </div>
-    );
-  }
 
   return (
     <ErrorBoundary>
@@ -576,8 +560,15 @@ export default function App() {
                                     element={<LeaderboardPage />}
                                   />
                                   <Route path="gamification/badges" element={<BadgesPage />} />
-                                  <Route path="login" element={<Login />} />
-                                  <Route path="connexion" element={<Login />} />
+                                  <Route
+                                    path="login"
+                                    element={<Login />}
+                                  />
+                                  <Route
+                                    path="connexion"
+                                    element={<Login />}
+                                  />
+                                  <Route path="aki-login" element={<AkiLogin />} />
                                   <Route path="inscription" element={<Inscription />} />
                                   <Route path="reset-password" element={<ResetPassword />} />
                                   <Route path="auth" element={<AuthHub />} />

--- a/frontend/src/context/authHook.ts
+++ b/frontend/src/context/authHook.ts
@@ -61,6 +61,8 @@ export type AuthContextValue = {
   signInFacebookRedirect: () => Promise<void>;
   signInApplePopup: () => Promise<void>;
   signInAppleRedirect: () => Promise<void>;
+  signInGithubPopup: () => Promise<void>;
+  signInGithubRedirect: () => Promise<void>;
   signOutUser: () => Promise<void>;
 };
 

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -13,6 +13,8 @@ import {
   signInFacebookRedirect,
   signInApplePopup,
   signInAppleRedirect,
+  signInGithubPopup,
+  signInGithubRedirect,
   signOutUser,
   signUpEmailPassword,
   subscribeToAuthState,
@@ -368,6 +370,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       signInAppleRedirect: async () => {
         setError(null);
         await signInAppleRedirect();
+      },
+      signInGithubPopup: async () => {
+        setError(null);
+        authLog('AUTH_CLICK_GITHUB', { mode: 'popup' });
+        transition('starting');
+        await signInGithubPopup();
+      },
+      signInGithubRedirect: async () => {
+        setError(null);
+        authLog('AUTH_REDIRECT_START', { provider: 'github', mode: 'redirect' });
+        transition('redirecting');
+        await signInGithubRedirect();
       },
       signOutUser: async () => {
         setError(null);

--- a/frontend/src/lib/firebase.ts
+++ b/frontend/src/lib/firebase.ts
@@ -14,14 +14,16 @@ import { getInstallations } from 'firebase/installations';
 // working without a .env file.  In production the secrets MUST be set so
 // the correct apiKey is embedded; the fallback is only a last resort.
 const firebaseConfig = {
-  apiKey: import.meta.env.VITE_FIREBASE_API_KEY || 'AIzaSyDf_m8BzMVHFWoFhVLyThuKwWTMhB7u5ZY',
-  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN || 'a-ki-pri-sa-ye.firebaseapp.com',
-  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID || 'a-ki-pri-sa-ye',
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY || 'AIzaSyDby4HIcb0K_-pZssF6OmKoSjNi7TcvqlQ',
+  authDomain:
+    import.meta.env.VITE_FIREBASE_AUTH_DOMAIN || 'akiprisaye-officielle.firebaseapp.com',
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID || 'akiprisaye-officielle',
   storageBucket:
-    import.meta.env.VITE_FIREBASE_STORAGE_BUCKET || 'a-ki-pri-sa-ye.firebasestorage.app',
-  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID || '187272078809',
-  appId: import.meta.env.VITE_FIREBASE_APP_ID || '1:187272078809:web:501d916973a75edb06e5c8',
-  measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID || 'G-W0R1B4HHE1',
+    import.meta.env.VITE_FIREBASE_STORAGE_BUCKET || 'akiprisaye-officielle.appspot.com',
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID || '147409182593',
+  appId:
+    import.meta.env.VITE_FIREBASE_APP_ID || '1:147409182593:web:75e81d77320548922b91c8',
+  measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID,
 };
 
 // Detect missing VITE_FIREBASE_* secrets so diagnostic pages (Login, StatutPage)

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,5 +1,6 @@
 import {
   FacebookAuthProvider,
+  GithubAuthProvider,
   GoogleAuthProvider,
   OAuthProvider,
   browserLocalPersistence,
@@ -21,6 +22,7 @@ import { auth } from '@/lib/firebase';
 
 const googleProvider = new GoogleAuthProvider();
 const facebookProvider = new FacebookAuthProvider();
+const githubProvider = new GithubAuthProvider();
 const appleProvider = new OAuthProvider('apple.com');
 
 // Request extra scopes for better profile info
@@ -28,6 +30,9 @@ googleProvider.addScope('profile');
 googleProvider.addScope('email');
 facebookProvider.addScope('email');
 facebookProvider.addScope('public_profile');
+githubProvider.addScope('read:user');
+githubProvider.addScope('user:email');
+githubProvider.setCustomParameters({ allow_signup: 'true' });
 appleProvider.addScope('email');
 appleProvider.addScope('name');
 
@@ -98,6 +103,12 @@ export async function signInApplePopup(): Promise<UserCredential> {
   return signInWithPopup(authInstance, appleProvider);
 }
 
+export async function signInGithubPopup(): Promise<UserCredential> {
+  const authInstance = ensureAuth();
+  await ensureSessionPersistence();
+  return signInWithPopup(authInstance, githubProvider);
+}
+
 export async function signOutUser(): Promise<void> {
   const authInstance = ensureAuth();
   await signOut(authInstance);
@@ -130,6 +141,12 @@ export async function signInAppleRedirect(): Promise<void> {
   const authInstance = ensureAuth();
   await ensureSessionPersistence();
   await signInWithRedirect(authInstance, appleProvider);
+}
+
+export async function signInGithubRedirect(): Promise<void> {
+  const authInstance = ensureAuth();
+  await ensureSessionPersistence();
+  await signInWithRedirect(authInstance, githubProvider);
 }
 
 /**

--- a/frontend/src/views/auth/AkiLogin.tsx
+++ b/frontend/src/views/auth/AkiLogin.tsx
@@ -1,0 +1,74 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { useAuth } from '@/context/authHook';
+import { getAuthErrorMessage } from '@/lib/authMessages';
+
+function isMobileDevice(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  return /Android|iPhone|iPad|iPod|IEMobile|Opera Mini/i.test(navigator.userAgent);
+}
+
+export default function AkiLogin() {
+  const navigate = useNavigate();
+  const {
+    user,
+    loading,
+    authFlowState,
+    signInGithubPopup,
+    signInGithubRedirect,
+    clearError,
+  } = useAuth();
+
+  useEffect(() => {
+    if (user) {
+      navigate('/', { replace: true });
+    }
+  }, [navigate, user]);
+
+  const handleGithubSignIn = async () => {
+    clearError();
+
+    try {
+      if (isMobileDevice()) {
+        await signInGithubRedirect();
+        return;
+      }
+      await signInGithubPopup();
+      navigate('/', { replace: true });
+    } catch (error) {
+      console.error('[AkiLogin] Erreur Firebase GitHub OAuth:', error);
+      console.error('[AkiLogin] Message normalisé:', getAuthErrorMessage(error));
+    }
+  };
+
+  const isBusy = loading || authFlowState === 'starting' || authFlowState === 'redirecting';
+
+  return (
+    <div className="min-h-screen bg-[#06090f] flex items-center justify-center p-6 text-white text-center">
+      <div className="w-full max-w-md bg-[#0d1117] p-10 rounded-[3rem] border border-blue-500/20 shadow-2xl">
+        <h2 className="text-2xl font-black mb-4 text-blue-500 italic">AKI HORIZON v18</h2>
+        <p className="text-[9px] text-gray-500 mb-8 uppercase tracking-widest">
+          ID: Ov23licp... · Firebase Redirect Handler actif
+        </p>
+        <button
+          type="button"
+          onClick={handleGithubSignIn}
+          disabled={isBusy}
+          className="w-full py-5 bg-[#24292f] text-white rounded-2xl font-black flex items-center justify-center gap-4 border border-white/10 active:scale-95 transition-all disabled:opacity-70"
+        >
+          <img
+            src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+            className="w-6 h-6 invert"
+            alt="GitHub"
+          />
+          {isBusy ? 'CONNEXION EN COURS…' : 'ENTRER VIA GITHUB'}
+        </button>
+
+        {authFlowState === 'redirecting' && (
+          <p className="text-xs text-slate-400 mt-4">Redirection sécurisée vers GitHub…</p>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Expose a GitHub-based sign-in flow and a dedicated login view for GitHub redirects to support alternative auth for users.
- Surface a small, focused login entry point (`aki-login`) that handles popup/redirect differences on mobile vs desktop.
- Wire the auth API surface to support GitHub alongside existing providers and update Firebase default config for the target project.

### Description
- Added a new view `views/auth/AkiLogin.tsx` implementing a GitHub sign-in button which uses popup on desktop and redirect on mobile. 
- Added `signInGithubPopup` and `signInGithubRedirect` to the auth service (`services/auth.ts`) and registered a `GithubAuthProvider` with scopes and parameters.
- Exposed GitHub sign-in actions in the auth context (`contexts/AuthContext.tsx` and `context/authHook.ts`) and hooked them into the provider value.
- Registered a new route `aki-login` in `App.tsx` and made small cleanup (removed unused `providerError` state and error UI path).
- Updated Firebase default config values in `lib/firebase.ts` (API key, authDomain, projectId, storageBucket, messagingSenderId, appId, measurementId fallback) to match the intended project defaults.

### Testing
- Ran a development type-check/build with `yarn build` which completed successfully.
- Executed unit tests with `yarn test` and they passed.
- Ran TypeScript checks with `yarn typecheck` and no type errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f00347aa7c832b850b0035e9e752b5)